### PR TITLE
Implementace odeslání zprávy do simpleApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ foreach ($messages as $message) {
 $simpleApi->findDataBoxById('wucb4dd');
 ```
 
+
+### Odeslání datové zprávy včetně přílohy
+
+Datová schránka nepřijímá všechny typy souborů, testováno na pdf, jpg, png (Většina binary typů by měla projít).
+TXT soubory lze odeslat pouze, kdyz se 2x base64 encodují, výsledkem je přijatá datová zpráva s base64 encodovaným contentem uvnitř txt souboru
+
+```php
+$files = [
+    '/path/to/a/file.pdf',
+];
+$message = $simpleApi->createBasicDataMessage('wucb4dd', 'Test', $files);
+$sentMessage = $simpleApi->sendDataMessage($message);
+if ($sentMessage->getDmStatus()->getDmStatusCode() !== "0000") {
+    // Handle errors
+}
+```
+
 ## Závěrem
 
 Všechny příklady nejdete ve složce examples. Pro připojení k datové schránce budete potřebovat login a heslo nebo testovací přístup, který lze získat na základě vyplnění [tohoto formuláře](https://www.datoveschranky.info/documents/1744842/1746073/zadost_zrizeni_testovaci_ds.zfo/4b75d5bf-0272-4305-9cef-8ec8f019e9d3).

--- a/src/ApiExtensions/dmFile.php
+++ b/src/ApiExtensions/dmFile.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Defr\CzechDataBox\ApiExtensions;
+
+
+class dmFile extends \Defr\CzechDataBox\Api\dmFile
+{
+    /**
+     * @var string
+     */
+    protected $dmEncodedContent = null;
+
+    /**
+     * @return string
+     */
+    public function getDmEncodedContent()
+    {
+        return $this->dmEncodedContent;
+    }
+
+    /**
+     * @param string $dmEncodedContent
+     *
+     * @return \Defr\CzechDataBox\ApiExtensions\dmFile
+     */
+    public function setDmEncodedContent($dmEncodedContent)
+    {
+        $this->dmEncodedContent = $dmEncodedContent;
+
+        return $this;
+    }
+
+}


### PR DESCRIPTION
Ahoj, trochu jsem se pral s odesíláním zpráv s attachmentama, tak bych chtěl nasdílet tuto úpravu.

Nějak se mi tam nezdá to generování některých API class, vůbec to nesedí na to, co se reálně musí poslat na backend czeboxu.

`tFilesArray`, a `dmFile` mi přijde špatně vygenerované, zkoušel jsem i aktualizovat WSDL (mám v jiné feature větvi), ale i tam je to chybně.

Pro `dmFile` jsem tam udělal extending class, přejmýšlím, zda neudělat i pro `tFilesArray`.

A pak mě hrozně mate, proč do `tMessageCreateInput` nemůžu poslat `dmEnvelope`, s ní ten request neprojde. Místo toho funguje `tMessageEnvelopeSub`.